### PR TITLE
Add tolerance to minimiziation

### DIFF
--- a/python/optiprofiler/problems.py
+++ b/python/optiprofiler/problems.py
@@ -593,7 +593,7 @@ class Problem:
 
             with warnings.catch_warnings():
                 warnings.simplefilter('ignore')
-                res = minimize(dist_x0_sq, self.x0, jac=True, hessp=lambda p: p, bounds=bounds, constraints=constraints)
+                res = minimize(dist_x0_sq, self.x0, jac=True, hessp=lambda p: p, bounds=bounds, constraints=constraints, tol=1e-16)
             self._x0 = res.x
 
     def _maxcv(self, x):


### PR DESCRIPTION
Problem 'PORTFL2' is a 12 dimensional problem with an equality constraint that forces the sum of the elements of x to be 1.

The provided x0 consists of 12 values of 1/12, but in single precision. When the minimization routine runs, it exits without doing anything because the sum is pretty close to 1.

However the starting point is still infeasible and this can cause problems for algorithms like LINCOA. In this case the starting point will always be infeasible since 1/12 cannot be represented in finite precision math, but by adding the tolerance we can reduce the initial constraint violation and provide a better starting point for LINCOA or any other algorithm that needs a feasible starting point.